### PR TITLE
test(strrchr): force unsigned char overflow

### DIFF
--- a/tests/srcs/test_ft_strrchr.c
+++ b/tests/srcs/test_ft_strrchr.c
@@ -56,6 +56,17 @@ void	test_negative_integer(void)
 	ASSERT_EXPR(result == expected);
 }
 
+void	test_integer_bigger_than_char_limit(void)
+{
+	char	test[] = "Lorem ipsum dolor sit amet.";
+	char	*result;
+	char	*expected;
+
+	result = ft_strrchr(test, 356);
+	expected = strrchr(test, 356);
+	ASSERT_EXPR(result == expected);
+}
+
 int	main(void)
 {
 	t_unit_test tests[] = {
@@ -64,6 +75,7 @@ int	main(void)
 		UNIT_TEST(test_locate_the_first_char),
 		UNIT_TEST(test_return_null_for_non_existing_char),
 		UNIT_TEST(test_negative_integer),
+		UNIT_TEST(test_integer_bigger_than_char_limit),
 	};
 	return RUN_GROUP(tests);
 }


### PR DESCRIPTION
force unsigned char overflow throw number int bigger than 255 (356 = d, so the expected string will be "dolor sit amet."). An possible solution is to create a new auxilliar pointer to the char c and then assign the return to that pointer before returning itself, as it follows:

char	*ft_strrchr(const char *s, int c)
{
	int		rev_index;
	char	*pointer;

	rev_index = ft_strlen(s);
	if (!rev_index && c)
		return (NULL);
	else if (!c || !rev_index)
	{
		pointer = (char *)&s[rev_index];
		return (pointer);
	}
	while (rev_index--)
	{
		if (s[rev_index] == (char)c)
		{
			pointer = (char *)&s[rev_index];
			return (pointer);
		}
	}
	return (NULL);
}