### PR TITLE
fix: make run clean first before build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ MANDATORY	= isalpha toupper isdigit tolower isalnum isascii isprint \
 				memset bzero memcpy memmove memchr memcmp atoi calloc strdup \
 				substr strjoin
 
-all: $(MANDATORY)
+all: fclean $(MANDATORY)
 		@make clean >/dev/null
 
 $(MANDATORY):	%:	$(OBJS)/test_ft_%.o $(UTIL_OBJ) $(LIB)


### PR DESCRIPTION
Expected:
 - Can run make N times to test the same function

What happened?
 - If some test breaks, the build is stopped and the object stays there when you run the command again `make`, if the file exists then it is skipped.